### PR TITLE
Added printing for all needed URLs for the android apps building phase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,12 @@ IE jumpbox:
 $(shell $(MAKE) -sC eudgc-ie print-ssh-cmd)
 
 
-To issue your first test Cert, in you Web Browser head to: $(shell $(MAKE) -sC eudgc-ie output-hostnames)
+To issue your first test Cert, in you Web Browser head to: $(shell $(MAKE) -sC eudgc-ie output-issuance-web-address)
 
+Required Endpoints to apply when building the Android Apps:
+- Issuance Service: $(shell $(MAKE) -sC eudgc-ie output-issuance-service-url)
+- Business Rule Service: $(shell $(MAKE) -sC eudgc-ie output-businessrule-service-url)
+- Verifier Service: $(shell $(MAKE) -sC eudgc-ie output-verifier-service-url)
 
 Enjoy! 😀
 

--- a/eudgc-ie/Makefile
+++ b/eudgc-ie/Makefile
@@ -38,4 +38,20 @@ workspace:
 
 .PHONY: output-hostnames
 output-hostnames:
+	@echo "$(shell cat $(ROOT_DIR)/output.json | jq '.[]["value"]' | sed "s/.*/&\//")"
+
+.PHONY: output-issuance-web-address
+output-issuance-web-address:
 	@echo "$(shell cat $(ROOT_DIR)/output.json | jq '.["issuance_web_address"]["value"]' | sed "s/.*/&\//")"
+
+.PHONY: output-issuance-service-url
+output-issuance-service-url:
+	@echo "$(shell cat $(ROOT_DIR)/output.json | jq '.["issuance_service_url"]["value"]' | sed "s/.*/&\//")"
+
+.PHONY: output-businessrule-service-url
+output-businessrule-service-url:
+	@echo "$(shell cat $(ROOT_DIR)/output.json | jq '.["businessrule_service_url"]["value"]' | sed "s/.*/&\//")"
+
+.PHONY: output-verifier-service-url
+output-verifier-service-url:
+	@echo "$(shell cat $(ROOT_DIR)/output.json | jq '.["verifier_service_url"]["value"]' | sed "s/.*/&\//")"

--- a/eudgc-ie/outputs.tf
+++ b/eudgc-ie/outputs.tf
@@ -1,4 +1,17 @@
 output "issuance_web_address" {
   value       = "https://dgca-issuance-web.${module.base_infra.dns_zone_name}"
-  description = "The web address where the issueance website can be accessed"
+  description = "The web address where the issuance website can be accessed"
+}
+output "issuance_service_url" {
+  value       = "https://dgca-issuance-service.${module.base_infra.dns_zone_name}"
+  description = "The url where the issuance backend can be accessed"
+}
+output "businessrule_service_url" {
+  value       = "https://dgca-businessrule-service.${module.base_infra.dns_zone_name}"
+  description = "The url where the business rule backend can be accessed"
+}
+
+output "verifier_service_url" {
+  value       = "https://dgca-verifier-service.${module.base_infra.dns_zone_name}"
+  description = "The url where the verifier service backend can be accessed"
 }


### PR DESCRIPTION
* Added printing for all needed URLs for the android apps building phase.
* Added a git tag of `v0.0.1` to this branch to allow for `git describe --long --tags` to print a useful Version identifier. 

Signed-off-by: ben <git@benjamin.ie>