### PR TITLE
Move to HSM Backed keys for CMK

### DIFF
--- a/terraform-modules/base-infrastructure/aks.tf
+++ b/terraform-modules/base-infrastructure/aks.tf
@@ -16,7 +16,7 @@ resource "azurerm_role_assignment" "aks_identity_dns_contributer" {
 resource "azurerm_key_vault_key" "aks_encryption_key" {
   name         = "aks-encryption-key"
   key_vault_id = azurerm_key_vault.keyvault.id
-  key_type     = "RSA"
+  key_type     = "RSA-HSM"
   key_size     = 2048
   key_opts     = ["unwrapKey", "wrapKey", ]
 

--- a/terraform-modules/base-infrastructure/mysql.tf
+++ b/terraform-modules/base-infrastructure/mysql.tf
@@ -2,7 +2,7 @@
 resource "azurerm_key_vault_key" "mysql_encryption_key" {
   name         = "mysql-encryption-key"
   key_vault_id = azurerm_key_vault.keyvault.id
-  key_type     = "RSA"
+  key_type     = "RSA-HSM"
   key_size     = 2048
   key_opts     = ["unwrapKey", "wrapKey", ]
 


### PR DESCRIPTION
Move to HSM backed keys for places we use customer managed keys. This ensures
the key cannot be copied out of the KeyVault instance, but can still be used
for the wrap / unwrap operations needed to decrypt the Data Encryption Key
used by AKS and Azure MySQL instances.

Signed-off-by: Graham Hayes <graham.hayes@microsoft.com>