### PR TITLE
Remove Azure ghcr.io hardcodes

### DIFF
--- a/.github/workflows/devcontainer.yaml
+++ b/.github/workflows/devcontainer.yaml
@@ -30,9 +30,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # GHCR Requires the image name to be lowercase, while
+      # `github.repository` will contain `Azure/...`.
+      - name: lowercase-repository
+        run: >-
+          GITHUB_REPO=${{ github.repository }};
+          echo "GITHUB_REPO_LWR=${GITHUB_REPO,,}" >> ${GITHUB_ENV};
+
       - name: Build and push
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .devcontainer/
           push: true
-          tags: ${{ env.REGISTRY }}/azure/eu-digital-covid-certificates-reference-architecture/devcontainer:latest
+          tags: ${{ env.REGISTRY }}/${{ env.GITHUB_REPO_LWR }}/devcontainer:latest

--- a/.github/workflows/upstream-dgc-gateway.yml
+++ b/.github/workflows/upstream-dgc-gateway.yml
@@ -79,6 +79,12 @@ jobs:
         env:
           APP_PACKAGES_USERNAME: ${{ github.actor }}
           APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      # GHCR Requires the image name to be lowercase, while
+      # `github.repository` will contain `Azure/...`.
+      - name: lowercase-repository
+        run: >-
+          GITHUB_REPO=${{ github.repository }};
+          echo "GITHUB_REPO_LWR=${GITHUB_REPO,,}" >> ${GITHUB_ENV};
       - name: docker
         working-directory: ./upstream/dgc-gateway
         run: >-
@@ -91,6 +97,6 @@ jobs:
           --tag "${APP_PACKAGES_URL}:${APP_VERSION}";
           docker push "${APP_PACKAGES_URL}:${APP_VERSION}";
         env:
-          APP_PACKAGES_URL: ghcr.io/azure/eu-digital-covid-certificates-reference-architecture/dgc-gateway
+          APP_PACKAGES_URL: ghcr.io/${{ env.GITHUB_REPO_LWR }}/dgc-gateway
           APP_PACKAGES_USERNAME: ${{ github.actor }}
           APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upstream-dgca-businessrule-service.yml
+++ b/.github/workflows/upstream-dgca-businessrule-service.yml
@@ -79,6 +79,12 @@ jobs:
         env:
           APP_PACKAGES_USERNAME: ${{ github.actor }}
           APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      # GHCR Requires the image name to be lowercase, while
+      # `github.repository` will contain `Azure/...`.
+      - name: lowercase-repository
+        run: >-
+          GITHUB_REPO=${{ github.repository }};
+          echo "GITHUB_REPO_LWR=${GITHUB_REPO,,}" >> ${GITHUB_ENV};
       - name: docker
         working-directory: ./upstream/dgca-businessrule-service
         run: >-
@@ -91,6 +97,6 @@ jobs:
           --tag "${APP_PACKAGES_URL}:${APP_VERSION}";
           docker push "${APP_PACKAGES_URL}:${APP_VERSION}";
         env:
-          APP_PACKAGES_URL: ghcr.io/azure/eu-digital-covid-certificates-reference-architecture/dgca-businessrule-service
+          APP_PACKAGES_URL: ghcr.io/${{ env.GITHUB_REPO_LWR }}/dgca-businessrule-service
           APP_PACKAGES_USERNAME: ${{ github.actor }}
           APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upstream-dgca-issuance-service.yml
+++ b/.github/workflows/upstream-dgca-issuance-service.yml
@@ -79,6 +79,12 @@ jobs:
         env:
           APP_PACKAGES_USERNAME: ${{ github.actor }}
           APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      # GHCR Requires the image name to be lowercase, while
+      # `github.repository` will contain `Azure/...`.
+      - name: lowercase-repository
+        run: >-
+          GITHUB_REPO=${{ github.repository }};
+          echo "GITHUB_REPO_LWR=${GITHUB_REPO,,}" >> ${GITHUB_ENV};
       - name: docker
         working-directory: ./upstream/dgca-issuance-service
         run: >-
@@ -91,6 +97,6 @@ jobs:
           --tag "${APP_PACKAGES_URL}:${APP_VERSION}";
           docker push "${APP_PACKAGES_URL}:${APP_VERSION}";
         env:
-          APP_PACKAGES_URL: ghcr.io/azure/eu-digital-covid-certificates-reference-architecture/dgca-issuance-service
+          APP_PACKAGES_URL: ghcr.io/${{ env.GITHUB_REPO_LWR }}/dgca-issuance-service
           APP_PACKAGES_USERNAME: ${{ github.actor }}
           APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upstream-dgca-issuance-web.yml
+++ b/.github/workflows/upstream-dgca-issuance-web.yml
@@ -50,6 +50,12 @@ jobs:
           APP_TAG=$(git describe --tags ${APP_REV} 2> /dev/null || echo 0.0.0);
           APP_VERSION=${APP_TAG}-${APP_SHA}-azure-${AZURE_VERSION};
           echo "APP_VERSION=${APP_VERSION}" >> ${GITHUB_ENV};
+      # GHCR Requires the image name to be lowercase, while
+      # `github.repository` will contain `Azure/...`.
+      - name: lowercase-repository
+        run: >-
+          GITHUB_REPO=${{ github.repository }};
+          echo "GITHUB_REPO_LWR=${GITHUB_REPO,,}" >> ${GITHUB_ENV};
       - name: docker
         working-directory: ./upstream/dgca-issuance-web
         run: >-
@@ -62,6 +68,6 @@ jobs:
           --tag "${APP_PACKAGES_URL}:${APP_VERSION}";
           docker push "${APP_PACKAGES_URL}:${APP_VERSION}";
         env:
-          APP_PACKAGES_URL: ghcr.io/azure/eu-digital-covid-certificates-reference-architecture/dgca-issuance-web
+          APP_PACKAGES_URL: ghcr.io/${{ env.GITHUB_REPO_LWR }}/dgca-issuance-web
           APP_PACKAGES_USERNAME: ${{ github.actor }}
           APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upstream-dgca-verifier-service.yml
+++ b/.github/workflows/upstream-dgca-verifier-service.yml
@@ -79,6 +79,12 @@ jobs:
         env:
           APP_PACKAGES_USERNAME: ${{ github.actor }}
           APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      # GHCR Requires the image name to be lowercase, while
+      # `github.repository` will contain `Azure/...`.
+      - name: lowercase-repository
+        run: >-
+          GITHUB_REPO=${{ github.repository }};
+          echo "GITHUB_REPO_LWR=${GITHUB_REPO,,}" >> ${GITHUB_ENV};
       - name: docker
         working-directory: ./upstream/dgca-verifier-service
         run: >-
@@ -91,6 +97,6 @@ jobs:
           --tag "${APP_PACKAGES_URL}:${APP_VERSION}";
           docker push "${APP_PACKAGES_URL}:${APP_VERSION}";
         env:
-          APP_PACKAGES_URL: ghcr.io/azure/eu-digital-covid-certificates-reference-architecture/dgca-verifier-service
+          APP_PACKAGES_URL: ghcr.io/${{ env.GITHUB_REPO_LWR }}/dgca-verifier-service
           APP_PACKAGES_USERNAME: ${{ github.actor }}
           APP_PACKAGES_PASSWORD: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Remove the hardcoded ghcr image names, to allow forks to use
the GitHub Workflows without modifications.