### PR TITLE
Ensure jumpbox-ssh-configs folder exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 terraform.tfvars
 *.log
 certs/
-eudcc-dev/jumpbox-ssh-configs/*
 .DS_Store
 *.tgz
 Chart.lock

--- a/eudcc-dev/jumpbox-ssh-configs/.gitignore
+++ b/eudcc-dev/jumpbox-ssh-configs/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
Ensure jumpbox-ssh-configs folder exists, as several places within the `Makefile`'s assumes it exists.