### PR TITLE
Add docs for making the Issuance Web ACL more restrictive

### DIFF
--- a/docs/content/en/deployment/web-authentication.md
+++ b/docs/content/en/deployment/web-authentication.md
@@ -1,0 +1,34 @@
+---
+title: "Issuance Web Authentication Setup"
+linkTitle: "Issuance Web Authentication"
+weight: 60
+description: >
+    Issuance Web Authentication Setup
+---
+
+## Issuance Web Authentication
+
+By default, when we deploy the issuance web application, the application is
+setup to allow all members of the AAD tenant to log into and issue certs.
+
+This is due to the need for an admin to grant consent to applications that have
+been directly assigned to users without their direct consent recorded in the
+AAD portal.
+
+### Restricting Access to Specific users
+
+- Navigate to https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/Overview
+- Search for the application name (The URL for issuance web that is printed at the end of the `make terraform` command, minus the "https://")
+  e.g. "dgca-issuance-web.eudcc-ie.example.com"
+- Click on the "enterprise application" result
+- Click on properties
+- Switch "User assignment required?" to "Yes"
+- Click on "Users and Groups"
+- Click "Add User/Group"
+- Search for either the user you want to grant access, or the group that contains the users you want to add
+- Leave role as "Default Access"
+- Click "Assign"
+- Click "Permissions"
+- Click "Grant admin consent for _ORG_"
+
+


### PR DESCRIPTION
A guide on moving from all users in a tenant being able to login to a subset.

Signed-off-by: Graham Hayes <graham.hayes@microsoft.com>