### PR TITLE
DGCA Web: Prevent proxied URLs from containing a double /

### DIFF
--- a/charts/dgca-issuance-web/Chart.yaml
+++ b/charts/dgca-issuance-web/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: dgca-issuance-web
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.9
+version: 0.1.10
 
 appVersion: "1.17.0"

--- a/charts/dgca-issuance-web/templates/configmap.yaml
+++ b/charts/dgca-issuance-web/templates/configmap.yaml
@@ -22,10 +22,10 @@ data:
         }
         location /dgca-issuance-service/ {
             proxy_ssl_server_name on;
-            proxy_pass ${DGCA_ISSUANCE_SERVICE_URL}/;
+            proxy_pass ${DGCA_ISSUANCE_SERVICE_URL};
         }
         location /dgca-businessrule-service/ {
             proxy_ssl_server_name on;
-            proxy_pass ${DGCA_BUSINESSRULE_SERVICE_URL}/;
+            proxy_pass ${DGCA_BUSINESSRULE_SERVICE_URL};
         }
     }


### PR DESCRIPTION
Previously, we had:

    proxy_pass ${DGCA_ISSUANCE_SERVICE_URL}/;

where DGCA_ISSUANCE_SERVICE_URL was set to:

    http://dgca-issuance-service.dgca-issuance-service.svc.cluster.local/

which would result in a final configuration of:

    proxy_pass http://dgca-issuance-service.dgca-issuance-service.svc.cluster.local//