### PR TITLE
Add a 'generation' variable

### DIFF
--- a/eudcc-eu/main.tf
+++ b/eudcc-eu/main.tf
@@ -27,9 +27,10 @@ locals {
 module "base_infra" {
   source = "../terraform-modules/base-infrastructure"
 
-  prefix   = var.prefix
-  name     = local.name
-  location = var.location
+  prefix     = var.prefix
+  generation = var.generation
+  name       = local.name
+  location   = var.location
 
   dev_vnet_rg_name = data.terraform_remote_state.dev.outputs.eu_rg_name
   dev_vnet_id      = data.terraform_remote_state.dev.outputs.eu_vnet_id

--- a/eudcc-eu/variables.tf
+++ b/eudcc-eu/variables.tf
@@ -4,6 +4,12 @@ variable "prefix" {
   default     = ""
 }
 
+variable "generation" {
+  type        = number
+  description = "Generation number to be appended to certain resource names (e.g. Purge Protected KeyVault's). Changing this value can only be done during a fresh deployment."
+  default     = 1
+}
+
 variable "location" {
   type        = string
   description = "Location Name"

--- a/eudcc-ie/main.tf
+++ b/eudcc-ie/main.tf
@@ -51,9 +51,10 @@ locals {
 module "base_infra" {
   source = "../terraform-modules/base-infrastructure"
 
-  prefix   = var.prefix
-  name     = local.name
-  location = var.location
+  prefix     = var.prefix
+  generation = var.generation
+  name       = local.name
+  location   = var.location
 
   dev_vnet_rg_name = data.terraform_remote_state.dev.outputs.ie_rg_name
   dev_vnet_id      = data.terraform_remote_state.dev.outputs.ie_vnet_id

--- a/eudcc-ie/variables.tf
+++ b/eudcc-ie/variables.tf
@@ -4,6 +4,12 @@ variable "prefix" {
   default     = ""
 }
 
+variable "generation" {
+  type        = number
+  description = "Generation number to be appended to certain resource names (e.g. Purge Protected KeyVault's). Changing this value can only be done during a fresh deployment."
+  default     = 1
+}
+
 variable "location" {
   type        = string
   description = "Location Name"

--- a/terraform-modules/base-infrastructure/keyvault.tf
+++ b/terraform-modules/base-infrastructure/keyvault.tf
@@ -1,11 +1,11 @@
 # KeyVault
 resource "azurerm_key_vault" "keyvault" {
-  name                        = "${var.prefix}${var.name}-keyvault"
+  name                        = "${var.prefix}${var.name}-keyvault-g${var.generation}"
   location                    = azurerm_resource_group.rg.location
   resource_group_name         = azurerm_resource_group.rg.name
   enabled_for_disk_encryption = true
   tenant_id                   = data.azurerm_client_config.current.tenant_id
-  soft_delete_retention_days  = 90
+  soft_delete_retention_days  = 7
   purge_protection_enabled    = true
   enable_rbac_authorization   = true
 

--- a/terraform-modules/base-infrastructure/variables.tf
+++ b/terraform-modules/base-infrastructure/variables.tf
@@ -1,7 +1,11 @@
 variable "prefix" {
   type        = string
   description = "Prefix"
-  default     = ""
+}
+
+variable "generation" {
+  type        = number
+  description = "Generation number to be appended to certain resource names (e.g. Purge Protected KeyVault's). Changing this value can only be done during a fresh deployment."
 }
 
 variable "name" {


### PR DESCRIPTION
This allows for more easily working around KV Purge Protection issues,
for example, if TF fails at just the right point, a certificate in KV
can end up in a state that Terraform does not correctly know how to
recover from. Incresing the `generation` var will force this TF stack
to create a wholly new KV to work around the issue.

*NOTE*: Once merged, all environments will need to be recreated.