### PR TITLE
Shorten Keyvault name

### DIFF
--- a/terraform-modules/base-infrastructure/keyvault.tf
+++ b/terraform-modules/base-infrastructure/keyvault.tf
@@ -1,6 +1,6 @@
 # KeyVault
 resource "azurerm_key_vault" "keyvault" {
-  name                        = "${var.prefix}${var.name}-keyvault-g${var.generation}"
+  name                        = "${var.prefix}${var.name}-kv-g${var.generation}"
   location                    = azurerm_resource_group.rg.location
   resource_group_name         = azurerm_resource_group.rg.name
   enabled_for_disk_encryption = true


### PR DESCRIPTION
The max length of a keyvault name is 24. Moving
keyvault->kv allows for a longer prefix to be used, and for > 10 generations

Signed-off-by: Graham Hayes <graham.hayes@microsoft.com>