### PR TITLE
Docs: Fix title & description of the generated TF IE stack page

### DIFF
--- a/docs/content/en/terraform/ie.md
+++ b/docs/content/en/terraform/ie.md
@@ -1,9 +1,9 @@
 ---
-title: "Ireland Terraform Stack"
-linkTitle: "Ireland Terraform Stack"
+title: "IE Terraform Stack"
+linkTitle: "IE Terraform Stack"
 weight: 30
 description: >
-    Docs for the EU Gateway deployment terraform
+    Docs for the Ireland country deployment terraform
 ---
 
 {{< tf-generated-warning >}}


### PR DESCRIPTION
Fix title & description of the generated TF IE stack page