### PR TITLE
Add minimum requirements for codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -19,5 +19,9 @@
     "mounts": [
         "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind",
         "source=${env:HOME}${env:USERPROFILE}/.azure,target=/root/.azure,type=bind",
-    ]
+    ],
+    "hostRequirements": {
+        "cpus": 16,
+        "memory": "16gb"
+    }
 }


### PR DESCRIPTION
Building android apps needs more resources than a basic codespaces allows for, so adding hints to the 
`.devcontainer/devcontainer.json` with minimum sizing requirements 

Signed-off-by: Graham Hayes <graham.hayes@microsoft.com>