### PR TITLE
Fix BaseURL for docs site

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,5 +1,5 @@
 
-baseURL = '/'
+baseURL = '/eu-digital-covid-certificates-reference-architecture/'
 languageCode = 'en'
 title = 'EU Digital COVID Certificate - Azure Reference Architecture'
 


### PR DESCRIPTION
Move to the new public base URL