### PR TITLE
Use prebuilt DevContainer image by default

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,14 @@
 {
-    "name": "EU Digital Green Cert Azure Reference",
-    "build": {
-        "dockerfile": "Dockerfile"
-    },
+    "name": "EU Digital Covid Certificate - Azure Reference Architecture",
+
+    // Option 1: Use the pre-built Dev Container image from GitHub
+    "image": "ghcr.io/azure/eu-digital-covid-certificates-reference-architecture/devcontainer:latest",
+
+    // Option 2: Build a Dev Container image locally
+    //"build": {
+    //    "dockerfile": "Dockerfile"
+    //},
+
     "containerUser": "vscode",
     "extensions": [
         "hashicorp.terraform"


### PR DESCRIPTION
Now that the repo and images are public, we can use the prebuilt devcontainer
image by default so that users don't need to build this themselves.